### PR TITLE
Update halo2wasm imports w/ newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@axiom-crypto/halo2-wasm": "^0.1.45",
+    "@axiom-crypto/halo2-wasm": "^0.1.46",
     "@axiom-crypto/tools": "^0.3.21",
     "ethers": "^6.7.1",
     "prettier": "1.18.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiom-crypto/halo2-js",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "description": "Halo2 Javascript library",
   "main": "index.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@axiom-crypto/halo2-wasm':
-    specifier: ^0.1.45
-    version: 0.1.45
+    specifier: ^0.1.46
+    version: 0.1.46
   '@axiom-crypto/tools':
     specifier: ^0.3.21
     version: 0.3.21
@@ -61,8 +61,8 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
-  /@axiom-crypto/halo2-wasm@0.1.45:
-    resolution: {integrity: sha512-uukgaoD1pXTLNVoICVtl29LdYL+I7IGyJn1QOdRDLwJa0TfRvsH79dYKJ1viyjdqca72IzKkrJW/Gb8y65po7Q==}
+  /@axiom-crypto/halo2-wasm@0.1.46:
+    resolution: {integrity: sha512-9DwCsXfd1lWi1vrI5i81FpD+CL22ob7RTiaKzmdJcJJbIGhzJh9Q0IBDl3Uvovpi+EB80lxjE3XgAcAKcr4yEA==}
     dev: false
 
   /@axiom-crypto/tools@0.3.21:

--- a/src/wasm/js/index.ts
+++ b/src/wasm/js/index.ts
@@ -1,4 +1,4 @@
-import { Halo2Wasm, init_panic_hook, Halo2LibWasm } from "@axiom-crypto/halo2-wasm/js/halo2_wasm";
+import { Halo2Wasm, init_panic_hook, Halo2LibWasm } from "@axiom-crypto/halo2-wasm/js";
 
 export const getHalo2Wasm = () => {
     init_panic_hook();

--- a/src/wasm/web/index.ts
+++ b/src/wasm/web/index.ts
@@ -1,4 +1,4 @@
-import init, { initThreadPool, init_panic_hook, Halo2Wasm, Halo2LibWasm } from "@axiom-crypto/halo2-wasm/web/halo2_wasm";
+import init, { initThreadPool, init_panic_hook, Halo2Wasm, Halo2LibWasm } from "@axiom-crypto/halo2-wasm/web";
 
 export const getHalo2Wasm = async (numThreads: number) => {
     await init();


### PR DESCRIPTION
Updates the imports for halo2-wasm. 

Need halo2-wasm https://github.com/axiom-crypto/halo2-wasm/pull/1 released + published for version compatibility.